### PR TITLE
Fix `ONCE` environment variable ignorance

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,4 +34,4 @@ RUN \
     curl -SLf https://github.com/docker/compose/releases/download/v${COMPOSE_VERSION}/docker-compose-linux-${DOWNLOAD_ARCH} -o /usr/local/lib/docker/cli-plugins/docker-compose && \
     chmod +x /usr/local/lib/docker/cli-plugins/docker-compose
 COPY --from=builder /go/src/app/main /usr/local/bin/docker-compose-watcher
-CMD ["docker-compose-watcher", "-once=0", "-printSettings"]
+CMD ["docker-compose-watcher", "-printSettings"]

--- a/src/settings.go
+++ b/src/settings.go
@@ -58,16 +58,18 @@ func (settings *Settings) boolFlagEnv(p *bool, name string, env string, value bo
 
 func (settings *Settings) int64FlagEnv(p *int64, name string, env string, value int64, usage string) {
 	flag.Int64Var(p, name, value, usage+" (env "+env+")")
-	if os.Getenv(env) != "" {
-		i, _ := strconv.ParseInt(os.Getenv(env), 10, 0)
+	val := os.Getenv(env)
+	if val != "" {
+		i, _ := strconv.ParseInt(val, 10, 0)
 		*p = i
 	}
 }
 
 func (settings *Settings) stringFlagEnv(p *string, name string, env string, value string, usage string) {
 	flag.StringVar(p, name, value, usage+" (env "+env+")")
-	if os.Getenv(env) != "" {
-		*p = os.Getenv(env)
+	val := os.Getenv(env)
+	if val != "" {
+		*p = val
 	}
 }
 

--- a/src/settings.go
+++ b/src/settings.go
@@ -33,7 +33,7 @@ func ReadSettings() {
 	s.boolFlagEnv(&s.Dry, "dry", "DRY", false, "dry run: check and pull, but don't restart")
 	s.boolFlagEnv(&s.Help, "help", "HELP", false, "print usage instructions")
 	s.int64FlagEnv(&s.Interval, "interval", "INTERVAL", 60, "interval in minutes between runs")
-	s.boolFlagEnv(&s.Once, "once", "ONCE", true, "run once and exit, do not run in background")
+	s.boolFlagEnv(&s.Once, "once", "ONCE", false, "run once and exit, do not run in background")
 	s.boolFlagEnv(&s.PrintSettings, "printSettings", "PRINT_SETTINGS", false, "print used settings")
 	s.stringFlagEnv(&s.UpdateLog, "updateLog", "UPDATE_LOG", "", "update log file")
 	//s.boolFlagEnv(&s.CompleteStop, "completeStop", "COMPLETE_STOP", false, "Restart all services in docker-compose.yml (even unmanaged) after a new image is pulled")

--- a/src/settings.go
+++ b/src/settings.go
@@ -60,7 +60,10 @@ func (settings *Settings) int64FlagEnv(p *int64, name string, env string, value 
 	flag.Int64Var(p, name, value, usage+" (env "+env+")")
 	val := os.Getenv(env)
 	if val != "" {
-		i, _ := strconv.ParseInt(val, 10, 0)
+		i, err := strconv.ParseInt(val, 10, 0)
+		if err != nil {
+			log.Fatal(err)
+		}
 		*p = i
 	}
 }

--- a/src/settings.go
+++ b/src/settings.go
@@ -5,7 +5,6 @@ import (
 	"log"
 	"os"
 	"strconv"
-	"strings"
 )
 
 // Settings holds the program runtime configuration
@@ -51,8 +50,12 @@ func ReadSettings() {
 func (settings *Settings) boolFlagEnv(p *bool, name string, env string, value bool, usage string) {
 	flag.BoolVar(p, name, value, usage+" (env "+env+")")
 	val := os.Getenv(env)
-	if (val != "") && (val != "0") && (strings.ToLower(val) != "false") {
-		*p = true
+	if val != "" {
+		b, err := strconv.ParseBool(val)
+		if err != nil {
+			log.Fatal(err)
+		}
+		*p = b
 	}
 }
 


### PR DESCRIPTION
Hi there,

Here's the MR to [fix the issue I have faced](https://github.com/virtualzone/compose-updater/issues/12) with `ONCE` environment variable being ignored, when executed via Docker.

One important note: this changes `docker-compose-watcher` (or, in fact, `compose-updater`) default value of `once` to false, so that it would be possible to remove `-once=0` from [Dockerfile](https://github.com/virtualzone/compose-updater/blob/master/Dockerfile#L37), but still keeping the old behavior:

```Dockerfile
CMD ["docker-compose-watcher", "-once=0", "-printSettings"]
```

The reason of removing this argument from `CMD` above is rather simple: due to code structure command line arguments takes precedence over environment variables, which I think is the right way to go. However, keeping `-once=0` will prevent ability to override behavior of passing environment variable `ONCE` to Docker.

Basically, this MR makes everyone happy.

Few other small things irrelevant to original issue comes as a bonus.